### PR TITLE
fix: 修复不安装kafka时kafka地址配置不正确的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 charts/metersphere/charts/
 requirements.lock
+charts/metersphere/Chart.lock

--- a/charts/metersphere/templates/03-modules/metersphere-server.yaml
+++ b/charts/metersphere/templates/03-modules/metersphere-server.yaml
@@ -87,11 +87,13 @@ spec:
           env: 
             - name: FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS
               value: "true"
+            {{if .Values.kafka.enabled }}
             - name: KAFKA_BOOTSTRAP-SERVERS
               valueFrom:
                 configMapKeyRef:
                   name: metersphere-config
                   key: kafka.bootstrap-servers
+            {{ end }}
           volumeMounts:
             - mountPath: /opt/metersphere/conf
               name: opt-metersphere-config

--- a/charts/metersphere/values.yaml
+++ b/charts/metersphere/values.yaml
@@ -54,7 +54,7 @@ server:
     kafka.partitions=1
     kafka.replicas=1
     kafka.topic={{.Values.common.kafka.metricTopic}}
-    kafka.bootstrap-servers={{.Values.common.kafka.host}}.{{.Release.Namespace}}:{{.Values.common.kafka.port}}
+    kafka.bootstrap-servers={{.Values.common.kafka.host}}:{{.Values.common.kafka.port}}
     kafka.log.topic={{.Values.common.kafka.logTopic}}
     kafka.test.topic={{.Values.common.kafka.testTopic}}
     kafka.report.topic={{.Values.common.kafka.reportTopic}}


### PR DESCRIPTION
当不通过该 chart 安装 kafka，直接配置 kafka 地址时，直接使用 configmap 中配置的 kafka 地址，不使用环境变量进行配置。
解决 https://github.com/metersphere/metersphere/issues/17730 中提到的问题。