### PR TITLE
修改wait-kafka写法以适配集群模式

### DIFF
--- a/charts/metersphere/templates/03-modules/metersphere-data-streaming.yaml
+++ b/charts/metersphere/templates/03-modules/metersphere-data-streaming.yaml
@@ -39,13 +39,22 @@ spec:
         - name: wait-kafka
           image: busybox:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              valueFrom:
+                configMapKeyRef:
+                  name: metersphere-config
+                  key: kafka.bootstrap-servers
           command:
             - sh
             - -c
             - |
               set -ex
-              until nc -zv {{ .Values.kafka.host }} {{ .Values.kafka.port }}; do sleep 5; done
-              sleep 10
+              for i in ${KAFKA_BOOTSTRAP_SERVERS//,/ };do
+                until nc -zv ${i%:*} ${i#*:};do sleep 5;done
+                echo "Kafka bootstrap $i is OK now."
+                sleep 5
+              done
       containers:
         - name: metersphere-data-streaming
           image: {{.Values.common.imagePrefix}}{{.Values.dataStreaming.image}}:{{.Values.common.imageTag}}

--- a/charts/metersphere/templates/03-modules/metersphere-node-controller.yaml
+++ b/charts/metersphere/templates/03-modules/metersphere-node-controller.yaml
@@ -29,13 +29,22 @@ spec:
         - name: wait-kafka
           image: busybox:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              valueFrom:
+                configMapKeyRef:
+                  name: metersphere-config
+                  key: kafka.bootstrap-servers
           command:
             - sh
             - -c
             - |
               set -ex
-              until nc -zv {{ .Values.kafka.host }} {{ .Values.kafka.port }}; do sleep 5; done
-              sleep 10
+              for i in ${KAFKA_BOOTSTRAP_SERVERS//,/ };do
+                until nc -zv ${i%:*} ${i#*:};do sleep 5;done
+                echo "Kafka bootstrap $i is OK now."
+                sleep 5
+              done
       containers:
         - name: metersphere-node-controller
           image: {{.Values.common.imagePrefix}}{{.Values.nodeController.image}}:{{.Values.common.imageTag}}


### PR DESCRIPTION
`metersphere-data-streaming.yaml`和`metersphere-node-controller.yaml`修改这两个文件的`wait-kafka`的写法。

当前写法使用外部kafka集群的时候会出现检查失败，一直卡主无法启动的问题。

修复写法后能正常启动。