### PR TITLE
fix/security: 为 pods 设置超级管理员权限以解决日志文件找不到的问题

### DIFF
--- a/charts/metersphere/templates/03-modules/metersphere.yaml
+++ b/charts/metersphere/templates/03-modules/metersphere.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app: metersphere
     spec:
+      securityContext:
+        runAsUser: 0 # 以超级管理员的方式执行，防止出现 Suppressed: java.io.FileNotFoundException: /opt/metersphere/logs/metersphere/warn.log
+        fsGroup: 0 # 以超级管理员的方式执行，防止出现 Suppressed: java.io.FileNotFoundException: /opt/metersphere/logs/metersphere/warn.log
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/metersphere/templates/03-modules/result-hub.yaml
+++ b/charts/metersphere/templates/03-modules/result-hub.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         app: result-hub
     spec:
+      securityContext:
+        runAsUser: 0 # 以超级管理员的方式执行，防止出现 Suppressed: java.io.FileNotFoundException: /opt/metersphere/logs/metersphere/warn.log
+        fsGroup: 0 # 以超级管理员的方式执行，防止出现 Suppressed: java.io.FileNotFoundException: /opt/metersphere/logs/metersphere/warn.log    
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/metersphere/templates/03-modules/task-runner.yaml
+++ b/charts/metersphere/templates/03-modules/task-runner.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         app: task-runner
     spec:
+      securityContext:
+        runAsUser: 0 # 以超级管理员的方式执行，防止出现 Suppressed: java.io.FileNotFoundException: /opt/metersphere/logs/metersphere/warn.log
+        fsGroup: 0 # 以超级管理员的方式执行，防止出现 Suppressed: java.io.FileNotFoundException: /opt/metersphere/logs/metersphere/warn.log     
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
- 在 metersphere、result-hub 和 task-runner 的 pod 模板中添加 securityContext 配置
- 设置 runAsUser 和 fsGroup 为 0，以超级管理员权限运行
- 这样可以防止出现 java.io.FileNotFoundException: /opt/metersphere/logs/metersphere/warn.log 的问题